### PR TITLE
add prior log probabilities, more representative nanomaggie/DN conversion factor

### DIFF
--- a/src/model_probability.jl
+++ b/src/model_probability.jl
@@ -1,6 +1,6 @@
 
 function compute_log_prior(ast::AsteroidParams, prior::Prior)
-    logpdf(prior.r, ast.r) * logpdf(prior.v, ast.v)
+    logpdf(prior.r, ast.r) + logpdf(prior.v, ast.v)
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,10 +13,10 @@ function test_truth_most_likely_with_all_synthetic_data()
 
     prior = sample_prior()
 
-    good_ast = AsteroidParams(10., [20, 12.], [3.1, 5.1])
+    good_ast = AsteroidParams(100000., [20, 12.], [3.1, 5.1])
     good_ll = compute_log_probability(good_ast, test_img, prior)
 
-    bad_ast = AsteroidParams(10., [19.4, 12.], [3.1, 5.1])
+    bad_ast = AsteroidParams(100000., [19.4, 12.], [3.1, 5.1])
     bad_ll = compute_log_probability(bad_ast, test_img, prior)
 
     info("$good_ll > $bad_ll")
@@ -33,10 +33,10 @@ function test_truth_most_likely_with_wise_psf()
     test_img = generate_sample_image(psf)
     prior = sample_prior()
 
-    good_ast = AsteroidParams(10., [20, 12.], [3.1, 5.1])
+    good_ast = AsteroidParams(100000., [20, 12.], [3.1, 5.1])
     good_ll = compute_log_probability(good_ast, test_img, prior)
 
-    bad_ast = AsteroidParams(10., [19.4, 12.], [3.1, 5.1])
+    bad_ast = AsteroidParams(100000., [19.4, 12.], [3.1, 5.1])
     bad_ll = compute_log_probability(bad_ast, test_img, prior)
 
     info("$good_ll > $bad_ll")

--- a/test/sample_data.jl
+++ b/test/sample_data.jl
@@ -8,7 +8,8 @@ end
 
 function generate_sample_image(psf::Matrix{Float64})
     H, W = 30, 30
-    nmgy_per_dn = 1 / 112  # is this realistic value?
+    # use the  band 2 value : 
+    nmgy_per_dn = 14.5 # approximate value for W2
     sky_noise_mean = 40 * nmgy_per_dn
     read_noise_var = 7.78  # in DN^2
     # Not sure if gain matters...the Poisson noise is in DN, not in number
@@ -20,7 +21,7 @@ function generate_sample_image(psf::Matrix{Float64})
     sky_read_rv = Normal(sky_noise_mean, sqrt(pixel_var))
     pixels = rand(sky_read_rv, H, W)
 
-    ast = AsteroidParams(10.3, [20, 12.], [3.1, 5.1])
+    ast = AsteroidParams(100000., [20, 12.], [3.1, 5.1])
     ast_r_dn = ast.r / nmgy_per_dn
     for w2 in 1:5, h2 in 1:5
         h = round(Int, ast.u[1]) + h2 - 3


### PR DESCRIPTION
Hi Jeff,

I changed the log probability multiplication to addition in `compute_log_prior`. I also noticed that we previously had `nmgy_per_dn=1/112`, whereas I felt a representative WISE value would be substantially different. I've now set `nmgy_per_dn = 14.5`, which is roughly the WISE W2 value. When I did this, I needed to correspondingly increase the test asteroid brightness in nanomaggies. My intuition was that since `nmgy_per_dn` increased by ~1000x, I should attempt to increase the test asteroid flux from ~10 nmgy to ~10,000 nmgy.

Oddly, when I did this, the unit test for the fake PSF passed, but the WISE PSF unit test did not. When I cranked the asteroid flux up to 100,000 nmgy, both tests passed. I found this kind of confusing/unexpected, but maybe I'm missing something or thinking about it wrong. Thanks.

-Aaron
