### PR TITLE
computes the probability of 0 or more asteroids

### DIFF
--- a/src/model_probability.jl
+++ b/src/model_probability.jl
@@ -1,6 +1,11 @@
 
 function compute_log_prior(asteroids::Vector{AsteroidParams}, prior::Prior)
-    sum([logpdf(prior.r, ast.r) + logpdf(prior.v, ast.v) for ast in asteroids])
+    lp = logpdf(prior.S, length(asteroids))
+    for ast in asteroids
+        lp += logpdf(prior.r, ast.r)
+        lp += logpdf(prior.v, ast.v)
+    end
+    lp
 end
 
 """

--- a/src/model_probability.jl
+++ b/src/model_probability.jl
@@ -1,6 +1,6 @@
 
-function compute_log_prior(ast::AsteroidParams, prior::Prior)
-    logpdf(prior.r, ast.r) + logpdf(prior.v, ast.v)
+function compute_log_prior(asteroids::Vector{AsteroidParams}, prior::Prior)
+    sum([logpdf(prior.r, ast.r) + logpdf(prior.v, ast.v) for ast in asteroids])
 end
 
 """
@@ -16,28 +16,38 @@ function extrapolate_position(u0::Vector{Float64}, v::Vector{Float64}, t::Float6
     u0 + v * t 
 end
 
-function compute_log_likelihood(ast::AsteroidParams, img::Image)
+function compute_log_likelihood(asteroids::Vector{AsteroidParams},
+        images::Vector{Image})
     ll = 0.
-    psf_dims = size(img.psf)
-    psf_center = [round(Int, (dim + 1) / 2) for dim in size(img.psf)]
-    u_t = extrapolate_position(ast.u, ast.v, img.t)
-    u_t_px = round(Int, u_t)
-    for w2 in 1:psf_dims[2], h2 in 1:psf_dims[1]
-        h = u_t_px[1] + h2 - psf_center[1]
-        w = u_t_px[2] + w2 - psf_center[2]
-        expected_ast_dn = (ast.r * img.psf[h2, w2]) / img.nmgy_per_dn
-        expected_pixel_dn = img.sky_noise_mean + expected_ast_dn
-        pixel_dn_var = expected_pixel_dn + img.read_noise_var
-        pixel_dist = Normal(expected_pixel_dn, sqrt(pixel_dn_var))
-        ll += logpdf(pixel_dist, img.pixels[h, w])
+
+    for img in images
+        psf_dims = size(img.psf)
+        psf_center = [round(Int, (dim + 1) / 2) for dim in size(img.psf)]
+        expected_dn = similar(img.pixels)
+        fill!(expected_dn, img.sky_noise_mean)
+
+        for ast in asteroids
+            u_t = extrapolate_position(ast.u, ast.v, img.t)
+            u_t_px = round(Int, u_t)
+            ast_r_dn = ast.r / img.nmgy_per_dn
+            for w2 in 1:psf_dims[2], h2 in 1:psf_dims[1]
+                h = u_t_px[1] + h2 - psf_center[1]
+                w = u_t_px[2] + w2 - psf_center[2]
+                expected_ast_dn = ast_r_dn * img.psf[h2, w2]
+                expected_dn[h, w] += expected_ast_dn
+            end
+        end
+
+        for w in 1:img.W, h in 1:img.H
+            pixel_dn_var = expected_dn[h, w] + img.read_noise_var
+            pixel_dist = Normal(expected_dn[h, w], sqrt(pixel_dn_var))
+            ll += logpdf(pixel_dist, img.pixels[h, w])
+        end
     end
+
     ll
 end
 
-
-function compute_log_likelihood(ast::AsteroidParams, img_stack::Vector{Image})
-    sum([compute_log_likelihood(ast, img) for img in img_stack])
-end
 
 
 """
@@ -48,8 +58,11 @@ arguments:
   ast: parameters for a candidate asteroid
   img: an astronomical image
 """
-function compute_log_probability(ast::AsteroidParams, 
-        img_data::Union(Image, Vector{Image}), prior::Prior)
-    compute_log_prior(ast, prior) + compute_log_likelihood(ast, img_data)
+function compute_log_probability(asteroids::Vector{AsteroidParams},
+        images::Vector{Image}, prior::Prior)
+    lp = compute_log_prior(asteroids, prior)
+    ll = compute_log_likelihood(asteroids, images)
+
+    lp + ll
 end
 

--- a/src/model_types.jl
+++ b/src/model_types.jl
@@ -27,6 +27,7 @@ immutable Prior
     r::LogNormal
     #TODO: specify a prior over asteroids' colors
     v::MvNormal
+    S::Poisson  # the number of asteroids in the images
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,10 +14,10 @@ function test_truth_most_likely_with_all_synthetic_data()
 
     prior = sample_prior()
 
-    good_ll = compute_log_probability(good_ast, test_img, prior)
+    good_ll = compute_log_probability([good_ast,], [test_img,], prior)
 
     bad_ast = AsteroidParams(good_ast.r, [19.4, 12.], good_ast.v)
-    bad_ll = compute_log_probability(bad_ast, test_img, prior)
+    bad_ll = compute_log_probability([bad_ast,], [test_img,], prior)
 
     info("$good_ll > $bad_ll")
     @test good_ll > bad_ll
@@ -37,10 +37,10 @@ function test_truth_most_likely_with_wise_psf()
 
     prior = sample_prior()
 
-    good_ll = compute_log_probability(good_ast, test_img, prior)
+    good_ll = compute_log_probability([good_ast,], [test_img,], prior)
 
     bad_ast = AsteroidParams(good_ast.r, [19.4, 12.], good_ast.v)
-    bad_ll = compute_log_probability(bad_ast, test_img, prior)
+    bad_ll = compute_log_probability([bad_ast,], [test_img,], prior)
 
     info("$good_ll > $bad_ll")
     @test good_ll > bad_ll
@@ -75,25 +75,25 @@ function test_truth_most_likely_with_real_bright_asteroid(band_id::Int64)
 
     ast_flux_nmgy = [10729.9, 47165.5]
     ast = AsteroidParams(ast_flux_nmgy[band_id], [15., 15.], [0., 0.])
-    good_ll = compute_log_probability(ast, real_img, prior)
+    good_ll = compute_log_probability([ast,], [real_img,], prior)
 
     # try an asteroid with the right brightness but wrong position
     bad_ast = AsteroidParams(ast.r, [20., 12.], ast.v)
-    bad_ll = compute_log_probability(bad_ast, real_img, prior)
+    bad_ll = compute_log_probability([bad_ast,], [real_img,], prior)
 
     info("$good_ll > $bad_ll")
     @test good_ll > bad_ll
 
     # try an asteroid with the right position but too faint
     bad_ast = AsteroidParams(0.1*ast.r,ast.u, ast.v)
-    bad_ll = compute_log_probability(bad_ast, real_img, prior)
+    bad_ll = compute_log_probability([bad_ast,], [real_img,], prior)
 
     info("$good_ll > $bad_ll")
     @test good_ll > bad_ll
 
     # try an asteroid with the right position but too bright
     bad_ast = AsteroidParams(10.0*ast.r,ast.u, ast.v)
-    bad_ll = compute_log_probability(bad_ast, real_img, prior)
+    bad_ll = compute_log_probability([bad_ast,], [real_img,], prior)
 
     info("$good_ll > $bad_ll")
     @test good_ll > bad_ll
@@ -111,19 +111,34 @@ function test_truth_most_likely_with_all_real_data()
 
     # Possible steps to writing this test:
     #
-    # 1. image_stack = <load images of 2005_UT453 taken in band 2>
+    # 1. images = <load images of 2005_UT453 taken in band 2>
     # 2. good_ast = <load the true band 2 brigthness of the 2005_UT453,
     #           its true position (in pixel coordinates at time 0)
     #           and its true velocity during the image exposures>
     #           Note: time 0 can be time of the first image in the stack
-    # 3. good_ll compute_log_prob(good_ast, image_stack, prior), where
+    # 3. good_ll compute_log_prob([good_ast,], images, prior), where
     #            prior is set like it's done in sample_prior(), but with
     #            more realistic values
     # 4. for a variety of bad_ast, some perhaps not all that different
     #    from good_ast, do 
-    #             bad_ll = compute_log_prob(bad_ast, image_stack, prior)
+    #             bad_ll = compute_log_prob([bad_ast,], images, prior)
     #    and
     #          @test bad_ll < good_ll
+end
+
+
+function test_variable_numbers_of_asteroids()
+    test_img = generate_sample_image()
+    prior = sample_prior()
+    good_ll = compute_log_probability([good_ast,], [test_img,], prior)
+
+    bad_ll_0 = compute_log_probability(AsteroidParams[], [test_img,], prior)
+    info("$good_ll > $bad_ll_0")
+    @test good_ll > bad_ll_0
+
+    bad_ll_2 = compute_log_probability([good_ast, good_ast], [test_img,], prior)
+    info("$good_ll > $bad_ll_2")
+    @test good_ll > bad_ll_2
 end
 
 
@@ -131,3 +146,5 @@ test_truth_most_likely_with_all_synthetic_data()
 test_truth_most_likely_with_wise_psf()
 test_truth_most_likely_with_real_bright_asteroid(2)
 test_truth_most_likely_with_all_real_data()
+test_variable_numbers_of_asteroids()
+

--- a/test/sample_data.jl
+++ b/test/sample_data.jl
@@ -46,10 +46,9 @@ end
 function sample_prior()
     # r_prior: mean = 7332; median = 4447; mode=1635; sd=9611
     r_prior = LogNormal(8.4, 1)
-
     v_prior = MvNormal([3., 5], [4. 1; 3 2]) # pixels / second
-
-    Prior(r_prior, v_prior)
+    S_prior = Poisson(1.3)
+    Prior(r_prior, v_prior, S_prior)
 end
 
 


### PR DESCRIPTION
Hi @ameisner , This PR lets you query `compute_log_probability` with an empty array of asteroids, to test another configuration against the null hypothesis.
