### PR TITLE
starting WISE utilities, extracting special numbers

### DIFF
--- a/src/KillerAsteroids.jl
+++ b/src/KillerAsteroids.jl
@@ -7,9 +7,11 @@ using Distributions
 include("model_types.jl")
 include("model_probability.jl")
 include("wise_psf.jl")
+include("wise_utils.jl")
 
 export Image, AsteroidParams, Prior
 export compute_log_probability, compute_log_likelihood
 export load_wise_psf
+export wise_params
 
 end # module

--- a/src/KillerAsteroids.jl
+++ b/src/KillerAsteroids.jl
@@ -12,6 +12,6 @@ include("wise_utils.jl")
 export Image, AsteroidParams, Prior
 export compute_log_probability, compute_log_likelihood
 export load_wise_psf
-export wise_params
+export wise_band_to_params
 
 end # module

--- a/src/wise_utils.jl
+++ b/src/wise_utils.jl
@@ -1,14 +1,16 @@
-function wise_params(band_id::Int64)
+immutable WiseBandParams
 
     # TODO: generalize to handle W3 and W4
     # TODO: add more parameters as they become relevant
 
-    nmgy_per_dn = [5.0, 14.5]
-    read_noise_var = [9.95, 7.78]
-    gain = [3.75, 4.60]
-
-    params = ["nmgy_per_dn" => nmgy_per_dn[band_id],
-              "read_noise_var" => read_noise_var[band_id], 
-              "gain" => gain[band_id]]
+    band_id::Int64
+    nmgy_per_dn::Float64
+    read_noise_var::Float64
+    gain::Float64
 
 end
+
+const wise_band_to_params = [
+   WiseBandParams(1, 5.0, 9.95, 3.75),
+   WiseBandParams(2, 14.5, 7.78, 4.6)
+]

--- a/src/wise_utils.jl
+++ b/src/wise_utils.jl
@@ -1,0 +1,14 @@
+function wise_params(band_id::Int64)
+
+    # TODO: generalize to handle W3 and W4
+    # TODO: add more parameters as they become relevant
+
+    nmgy_per_dn = [5.0, 14.5]
+    read_noise_var = [9.95, 7.78]
+    gain = [3.75, 4.60]
+
+    params = ["nmgy_per_dn" => nmgy_per_dn[band_id],
+              "read_noise_var" => read_noise_var[band_id], 
+              "gain" => gain[band_id]]
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -63,12 +63,13 @@ function test_truth_most_likely_with_real_bright_asteroid(band_id::Int64)
     H = sz[1]
     W = sz[2]
 
-    par = wise_params(band_id)
+    par = wise_band_to_params[band_id]
+
     sky_noise_mean = [22, 53]
 
-    real_img = Image(H, W, pixels, par["nmgy_per_dn"], 
-                     sky_noise_mean[band_id], par["read_noise_var"], 
-                     par["gain"], psf, band_id, 0.)
+    real_img = Image(H, W, pixels, par.nmgy_per_dn, 
+                     sky_noise_mean[band_id], par.read_noise_var, 
+                     par.gain, psf, band_id, 0.)
 
     prior = sample_prior()
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -62,14 +62,13 @@ function test_truth_most_likely_with_real_bright_asteroid(band_id::Int64)
 
     H = sz[1]
     W = sz[2]
-    nmgy_per_dn = [5.0, 14.5]
-    sky_noise_mean = [22, 53]
-    read_noise_var = [9.95, 7.78]
-    gain = [3.75, 4.60]
 
-    real_img = Image(H, W, pixels, nmgy_per_dn[band_id], 
-                     sky_noise_mean[band_id], read_noise_var[band_id], 
-                     gain[band_id], psf, band_id, 0.)
+    par = wise_params(band_id)
+    sky_noise_mean = [22, 53]
+
+    real_img = Image(H, W, pixels, par["nmgy_per_dn"], 
+                     sky_noise_mean[band_id], par["read_noise_var"], 
+                     par["gain"], psf, band_id, 0.)
 
     prior = sample_prior()
 


### PR DESCRIPTION
Hi Jeff,

I'm getting started on putting various WISE utilities in place. As a first step, I wanted to have a "repository" for various WISE special numbers like `gain`, `read_noise_var` and `nmgy_per_dn`, to avoid having to specify these explicitly in numerous places throughout the codebase.

Right now, I do this with a utility function that returns a dictionary of the parameters. Let me know if there's a more appropriate way to be doing this in Julia. Thanks.

-Aaron 
