### PR TITLE
fix case of asteroid partially off image edge

### DIFF
--- a/src/model_probability.jl
+++ b/src/model_probability.jl
@@ -38,6 +38,9 @@ function compute_log_likelihood(asteroids::Vector{AsteroidParams},
             for w2 in 1:psf_dims[2], h2 in 1:psf_dims[1]
                 h = u_t_px[1] + h2 - psf_center[1]
                 w = u_t_px[2] + w2 - psf_center[2]
+                if (h > img.H) || (w > img.W) || (h < 1) || (w < 1)  
+                    continue
+                end
                 expected_ast_dn = ast_r_dn * img.psf[h2, w2]
                 expected_dn[h, w] += expected_ast_dn
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -141,6 +141,38 @@ function test_variable_numbers_of_asteroids()
     @test good_ll > bad_ll_2
 end
 
+function test_asteroid_partially_off_edge()
+
+    band_id = 1
+    halfsidelen = 10
+    psf = load_wise_psf(band_id, halfsidelen)
+    psf /= sum(psf)
+
+    fdir = joinpath(Pkg.dir("KillerAsteroids"), "dat")
+    fname = string("stereoskopia_w", string(band_id),".fits")
+    fname = joinpath(fdir, fname)
+
+    f = FITS(fname)
+    pixels = read(f[1])
+
+    sz = size(pixels)
+
+    H = sz[1]
+    W = sz[2]
+
+    par = wise_band_to_params[band_id]
+
+    sky_noise_mean = 22
+
+    real_img = Image(H, W, pixels, par.nmgy_per_dn, 
+                     sky_noise_mean, par.read_noise_var, 
+                     par.gain, psf, band_id, 0.)
+
+    prior = sample_prior()
+    edge_ast = AsteroidParams(10729.9, [25, 15], [0., 0.])
+    edge_ll = compute_log_probability([edge_ast,], [real_img,], prior)
+
+end
 
 test_truth_most_likely_with_all_synthetic_data()
 test_truth_most_likely_with_wise_psf()
@@ -148,4 +180,4 @@ test_truth_most_likely_with_real_bright_asteroid(1)
 test_truth_most_likely_with_real_bright_asteroid(2)
 test_truth_most_likely_with_all_real_data()
 test_variable_numbers_of_asteroids()
-
+test_asteroid_partially_off_edge()


### PR DESCRIPTION
Hi Jeff,

I noticed that it was possible to get a `BoundsError()` in `compute_log_likelihood` for an asteroid with a PSF that runs partially off the image edge. So I fixed that and added a unit test. I believe this same issue comes up in `sample_data.jl` where the synthetic image is generated. But I haven't gotten around to fixing that. 

There are variations on this that I haven't thought about carefully or tested. For instance, I think we do want to be able to handle the case where an asteroid's centroid is outside of the image, but the wings of its PSF still contribute to the image model.

Lastly, I realize that the unit test I added doesn't conform to the usual `@test` framework. Not sure how to massage the test into a proper format. Maybe something like a try/catch for the `BoundsError()`. Thanks.

-Aaron
