### PR TITLE
interpolates the psf based on the hypothesized location of an asteroid

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,4 +2,4 @@ julia 0.4.0-rc1
 Distributions
 FITSIO
 WCSLIB
-SloanDigitalSkySurvey
+Interpolations

--- a/src/KillerAsteroids.jl
+++ b/src/KillerAsteroids.jl
@@ -3,6 +3,7 @@ module KillerAsteroids
 using FITSIO
 using WCSLIB
 using Distributions
+using Interpolations
 
 include("model_types.jl")
 include("model_probability.jl")


### PR DESCRIPTION
HI @ameisner , This PR interpolates the PSF using the "Interpolations.jl" package, rather than just rounding the location of the asteroid to the nearest pixel. It's just linear interpolation but I suspect that will suffice. (The Interpolations package also support quadratic interpolation.) Would you test that it works for the case that was failing before? (where brightness was formerly too low)
