### PR TITLE
compute log probability for a grid of trial fluxes

### DIFF
--- a/test/test_flux_accuracy.jl
+++ b/test/test_flux_accuracy.jl
@@ -1,0 +1,21 @@
+using KillerAsteroids
+
+include("sample_data.jl")
+
+function flux_accuracy_all_synthetic_data()
+
+    fac_min = 0.75 # 0.75 times as bright
+    fac_max = 1.25 # 1.25 times as bright
+    nfac = 51
+    fac_vals = linspace(fac_min, fac_max, nfac)
+    lp_vals = zeros(nfac)
+
+    for i=1:nfac
+         test_ast = AsteroidParams(fac_vals[i]*sample_ast.r, sample_ast.u, sample_ast.v)
+         test_lp = compute_log_probability([test_ast,], [sample_img,], sample_prior)
+         lp_vals[i] = test_lp
+    end
+
+    lp_max, indbest = findmax(lp_vals)
+    return fac_vals[indbest]
+end


### PR DESCRIPTION
I looked into the accuracy of the maximum probability flux for the case of completely synthetic data with the asteroid centered on one of the image pixels. I ran 500 realizations, and found the median flux to be 1.02 times the true flux (histogram embedded below). That's much better agreement than I was finding for the real data (~1.1-1.2 depending on the band). It occurred to me that the flux prior would be able to drag the maximum probability flux around a bit, but it actually looks like the prior mean is lower than the sample asteroid's flux.

![histogram of fluxes](http://faun.rc.fas.harvard.edu/ameisner/test_flux_accuracy.png)
